### PR TITLE
Update makeOM.R

### DIFF
--- a/inst/shiny_apps/MERA/Source/OM/makeOM.R
+++ b/inst/shiny_apps/MERA/Source/OM/makeOM.R
@@ -296,7 +296,7 @@ makeOM<-function(PanelState,nyears=NA,maxage=NA,proyears=NA,UseQonly=F){
     
     OM1@cpars$MPA<-matrix(1,nrow=OM1@nyears+OM1@proyears,ncol=3)
     OM1@cpars$MPA[1:(Nyears-1),3]<-0
-    OM1@cpars$MPA[Nyears:proyears,1]<-0
+    OM1@cpars$MPA[Nyears+(0:OM1@proyears),1]<-0
  
     # Initial depletion                                                                      # F19 ----------
     initDrng<-getminmax(1,"Dh",PanelState)


### PR DESCRIPTION
I think the indices  at which "Area 1" was closed in the MPA cpars are slightly off; with default nyears/proyears  area 1 closes for only about 10/20 years (difference between proyears and nyears) rather than the full projection time line (and if proyears are fewer than nyears they would retroactively close area 1 in the historical period).
